### PR TITLE
More concise breadcrumb props for redux actions

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -21,7 +21,8 @@ export default function createMiddleware(dsn, cfg={}) {
   return store => next => action => {
     try {
       Raven.captureBreadcrumb({
-        data: { redux: action.type }
+        category: 'redux',
+        message: action.type
       });
 
       return next(action);


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/2153/17795372/a632eb0e-656c-11e6-93bc-16932e8e02ad.png)

After:

![image](https://cloud.githubusercontent.com/assets/2153/17795357/90d7f506-656c-11e6-8d26-3a370df780b0.png)

This also makes it possible to filter on redux items in the Sentry UI (can currently search on category/message, but not nested object key/values):

![image](https://cloud.githubusercontent.com/assets/2153/17795390/cefd015a-656c-11e6-89bc-d4cb825e031c.png)

See also: Sentry's [breadcrumbs client API spec](https://docs.sentry.io/hosted/learn/breadcrumbs/)
