### PR TITLE
Added options to customize middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@ on dispatching any action. redux-raven-middleware will pass in the error as
 well as extra information such as the action that caused the error and the
 entire Redux application state.
 
-## RavenMiddleware(sentryDSN, sentryConfig)
+## RavenMiddleware(sentryDSN, sentryConfig, middlewareOptions)
 
 Creates a Raven Middleware.
 
-- sentryDSN -- string representing your Sentry instance.
-- sentryConfig -- object that will be passed into Raven.config.
+- `sentryDSN` -- string representing your Sentry instance.
+- `sentryConfig` -- object that will be passed into Raven.config.
+- `middlewareOptions` -- object to customize the middleware:
+ - `actionTransformer` -- transform the action before sending to Sentry
+ - `stateTransformer` -- transform the state before sending to Sentry
+ - `logger` -- log function to use instead of `console.error`
 
 ```js
 import {applyMiddleware, createStore} from 'redux';

--- a/index.es6
+++ b/index.es6
@@ -1,11 +1,17 @@
 import Raven from 'raven-js';
 
-export default function createMiddleware(dsn, cfg={}) {
+const identity = stuff => stuff;
+
+export default function createMiddleware(dsn, cfg={}, options={}) {
   /*
     Function that generates a crash reporter for Sentry.
 
     dsn - private Sentry DSN.
     cfg - object to configure Raven.
+    options - customize extra data sent to sentry
+      actionTransformer - tranform the action object to send; default to identity function
+      stateTransformer - transform the state object to send; default to identity function
+      logger - the logger to use for logging; default to console.error
   */
   if (!Raven.isSetup()) {
     if (!dsn) {
@@ -19,6 +25,11 @@ export default function createMiddleware(dsn, cfg={}) {
   }
 
   return store => next => action => {
+    const {
+      actionTransformer = identity,
+      stateTransformer = identity,
+      logger = console.error
+    } = options;
     try {
       Raven.captureBreadcrumb({
         category: 'redux',
@@ -27,13 +38,13 @@ export default function createMiddleware(dsn, cfg={}) {
 
       return next(action);
     } catch (err) {
-      console.error('[redux-raven-middleware] Reporting error to Sentry:', err);
+      logger('[redux-raven-middleware] Reporting error to Sentry:', err);
 
       // Send the report.
       Raven.captureException(err, {
         extra: {
-          action: action,
-          state: store.getState(),
+          action: actionTransformer(action),
+          state: stateTransformer(store.getState()),
         }
       });
     }

--- a/index.es6
+++ b/index.es6
@@ -28,7 +28,7 @@ export default function createMiddleware(dsn, cfg={}, options={}) {
     const {
       actionTransformer = identity,
       stateTransformer = identity,
-      logger = console.error
+      logger = console.error.bind(console, '[redux-raven-middleware] Reporting error to Sentry:')
     } = options;
     try {
       Raven.captureBreadcrumb({
@@ -38,7 +38,7 @@ export default function createMiddleware(dsn, cfg={}, options={}) {
 
       return next(action);
     } catch (err) {
-      logger('[redux-raven-middleware] Reporting error to Sentry:', err);
+      logger(err);
 
       // Send the report.
       Raven.captureException(err, {

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function createMiddleware(dsn) {
         var _options$stateTransformer = options.stateTransformer;
         var stateTransformer = _options$stateTransformer === undefined ? identity : _options$stateTransformer;
         var _options$logger = options.logger;
-        var logger = _options$logger === undefined ? console.error : _options$logger;
+        var logger = _options$logger === undefined ? console.error.bind(console, '[redux-raven-middleware] Reporting error to Sentry:') : _options$logger;
 
         try {
           _ravenJs2['default'].captureBreadcrumb({
@@ -61,7 +61,7 @@ function createMiddleware(dsn) {
 
           return next(action);
         } catch (err) {
-          logger('[redux-raven-middleware] Reporting error to Sentry:', err);
+          logger(err);
 
           // Send the report.
           _ravenJs2['default'].captureException(err, {

--- a/test.es6
+++ b/test.es6
@@ -27,6 +27,7 @@ describe('createRavenMiddleware', () => {
   jsdom();
   const createRavenMiddleware = require('./index');
   const Raven = require('raven-js');
+  const ravenSpy = sinon.spy(Raven, 'captureException');
 
   beforeEach(() => {
     sinon.stub(Raven, 'config', () => {
@@ -35,6 +36,7 @@ describe('createRavenMiddleware', () => {
   });
   afterEach(() => {
     Raven.config.restore();
+    ravenSpy.reset();
   });
 
   it('returns middleware', () => {
@@ -65,12 +67,38 @@ describe('createRavenMiddleware', () => {
   });
 
   it('reports error', () => {
-    const ravenSpy = sinon.spy(Raven, 'captureException');
     createRavenMiddleware('abc')(stubStore)(mockNextHandler)({error: true});
 
     assert.equal(ravenSpy.args[0][0].constructor, Error);
     assert.equal(ravenSpy.args[0][0].message, 'Test Error');
     assert.deepEqual(ravenSpy.args[0][1].extra.action, {error: true});
     assert.deepEqual(ravenSpy.args[0][1].extra.state, {test: 'test'});
+  });
+
+  it('reports error with transformed state and action', () => {
+    const actionTransformer = action => action.error
+    const stateTransformer = state => state.test
+    const cfg = {}
+    const opts = { actionTransformer, stateTransformer }
+    createRavenMiddleware('abc', cfg, opts)(stubStore)(mockNextHandler)({error: true});
+
+    assert.equal(ravenSpy.args[0][0].constructor, Error);
+    assert.equal(ravenSpy.args[0][0].message, 'Test Error');
+    assert.equal(ravenSpy.args[0][1].extra.action, true);
+    assert.equal(ravenSpy.args[0][1].extra.state, 'test');
+  });
+
+  it('logs via custom logger', () => {
+    const logger = sinon.spy()
+    const cfg = {}
+    const opts = { logger }
+    createRavenMiddleware('abc', cfg, opts)(stubStore)(mockNextHandler)({error: true});
+
+    assert.equal(ravenSpy.args[0][0].constructor, Error);
+    assert.equal(ravenSpy.args[0][0].message, 'Test Error');
+    assert.deepEqual(ravenSpy.args[0][1].extra.action, {error: true});
+    assert.deepEqual(ravenSpy.args[0][1].extra.state, {test: 'test'});
+    assert(logger.calledOnce, 'logs one message')
+    assert(logger.args[0][0].indexOf('[redux-raven-middleware]') === 0, 'logs the correct message')
   });
 });

--- a/test.es6
+++ b/test.es6
@@ -99,6 +99,6 @@ describe('createRavenMiddleware', () => {
     assert.deepEqual(ravenSpy.args[0][1].extra.action, {error: true});
     assert.deepEqual(ravenSpy.args[0][1].extra.state, {test: 'test'});
     assert(logger.calledOnce, 'logs one message')
-    assert(logger.args[0][0].indexOf('[redux-raven-middleware]') === 0, 'logs the correct message')
+    assert.equal(logger.args[0][0], ravenSpy.args[0][0])
   });
 });

--- a/test.js
+++ b/test.js
@@ -117,6 +117,6 @@ describe('createRavenMiddleware', function () {
     _assert2['default'].deepEqual(ravenSpy.args[0][1].extra.action, { error: true });
     _assert2['default'].deepEqual(ravenSpy.args[0][1].extra.state, { test: 'test' });
     (0, _assert2['default'])(logger.calledOnce, 'logs one message');
-    (0, _assert2['default'])(logger.args[0][0].indexOf('[redux-raven-middleware]') === 0, 'logs the correct message');
+    _assert2['default'].equal(logger.args[0][0], ravenSpy.args[0][0]);
   });
 });


### PR DESCRIPTION
Added the following options to customize the middleware:
- `actionTransformer`: a function that transforms the action before sending to Sentry
- `stateTransformer`: a function that transforms the state before sending to Sentry
- `logger`: a logger to use instead of `console.error`

The transformers are useful for staying within [the Sentry attribute limits](https://docs.sentry.io/hosted/learn/quotas/#attributes-limits).

The logger allows circumventing customized `console`s like in React Native, in which case `captureException` never gets executed.
