### PR TITLE
Remove jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   "devDependencies": {
     "babel": "^5.4.7",
     "babel-runtime": "^5.8.20",
-    "jsdom": "^3.1.2",
     "mocha": "^2.2.5",
-    "mocha-jsdom": "^1.0.0",
     "sinon": "^1.16.1"
   },
   "scripts": {

--- a/test.es6
+++ b/test.es6
@@ -1,15 +1,5 @@
 import assert from 'assert';
-import _jsdom from 'jsdom';
-import mochaJsdom from 'mocha-jsdom';
 import sinon from 'sinon';
-
-
-// Need jsdom since Raven uses `window.setTimeout` because specifying `window`
-// is totally necessary.
-global.document = _jsdom.jsdom('<html><body></body></html>');
-global.window = document.parentWindow;
-global.navigator = window.navigator;
-const jsdom = mochaJsdom.bind(this, {skipWindowCheck: true});
 
 
 const stubStore = {
@@ -24,7 +14,6 @@ const mockNextHandler = action => {
 
 
 describe('createRavenMiddleware', () => {
-  jsdom();
   const createRavenMiddleware = require('./index');
   const Raven = require('raven-js');
   const ravenSpy = sinon.spy(Raven, 'captureException');

--- a/test.js
+++ b/test.js
@@ -6,24 +6,9 @@ var _assert = require('assert');
 
 var _assert2 = _interopRequireDefault(_assert);
 
-var _jsdom2 = require('jsdom');
-
-var _jsdom3 = _interopRequireDefault(_jsdom2);
-
-var _mochaJsdom = require('mocha-jsdom');
-
-var _mochaJsdom2 = _interopRequireDefault(_mochaJsdom);
-
 var _sinon = require('sinon');
 
 var _sinon2 = _interopRequireDefault(_sinon);
-
-// Need jsdom since Raven uses `window.setTimeout` because specifying `window`
-// is totally necessary.
-global.document = _jsdom3['default'].jsdom('<html><body></body></html>');
-global.window = document.parentWindow;
-global.navigator = window.navigator;
-var jsdom = _mochaJsdom2['default'].bind(undefined, { skipWindowCheck: true });
 
 var stubStore = {
   getState: function getState() {
@@ -38,7 +23,6 @@ var mockNextHandler = function mockNextHandler(action) {
 };
 
 describe('createRavenMiddleware', function () {
-  jsdom();
   var createRavenMiddleware = require('./index');
   var Raven = require('raven-js');
   var ravenSpy = _sinon2['default'].spy(Raven, 'captureException');


### PR DESCRIPTION
The version of JSDOM we were requiring fails to installs properly on my
machine.

Upon closer inspection, it seems the modern version of raven-js nolonger needs
a window, so we can omit JSDOM all together.