### PR TITLE
Proposal: Defer Sentry reporting to raven-for-redux

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -1,6 +1,5 @@
 import Raven from 'raven-js';
-
-const identity = stuff => stuff;
+import createRavenMiddleware from 'raven-for-redux';
 
 export default function createMiddleware(dsn, cfg={}, options={}) {
   /*
@@ -11,7 +10,8 @@ export default function createMiddleware(dsn, cfg={}, options={}) {
     options - customize extra data sent to sentry
       actionTransformer - tranform the action object to send; default to identity function
       stateTransformer - transform the state object to send; default to identity function
-      logger - the logger to use for logging; default to console.error
+      breadcrumbDataFromAction - derive a breadcrumb `data` object from each action; default to noop
+      breadcrumbCategory - category for redux action breadcrumbs; default "redux"
   */
   if (!Raven.isSetup()) {
     if (!dsn) {
@@ -24,29 +24,7 @@ export default function createMiddleware(dsn, cfg={}, options={}) {
     Raven.config(dsn, cfg).install();
   }
 
-  return store => next => action => {
-    const {
-      actionTransformer = identity,
-      stateTransformer = identity,
-      logger = console.error.bind(console, '[redux-raven-middleware] Reporting error to Sentry:')
-    } = options;
-    try {
-      Raven.captureBreadcrumb({
-        category: 'redux',
-        message: action.type
-      });
+  options.breadcrumbCategory = options.breadcrumbCategory || "redux";
 
-      return next(action);
-    } catch (err) {
-      logger(err);
-
-      // Send the report.
-      Raven.captureException(err, {
-        extra: {
-          action: actionTransformer(action),
-          state: stateTransformer(store.getState()),
-        }
-      });
-    }
-  }
+  return createRavenMiddleware(Raven, options);
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "redux-raven-middleware",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Redux middleware for sending error reports to Sentry through raven-js.",
   "main": "./index.js",
   "dependencies": {
-    "raven-js": "^3.1.1"
+    "raven-for-redux": "^1.0.0",
+    "raven-js": "^3.9.0"
   },
   "devDependencies": {
     "babel": "^5.4.7",


### PR DESCRIPTION
*Do not merge!* This is just a proof of concept. If we like it, I will update
tests and the README to reflect this change.

redux-raven-middleware is actually a superset of raven-for-redux, so I figured
I would propose a merger. This would allow users of redux-raven-middleware to
gain some of the advantages of raven-for-redux without having to change any of
their code. It would also avoid having two libraries duplicating the same
effort.

Advantages
---

* Add state/last-action to Raven as context for all errors, not just reducer errors (#21)
* Option to add `data` to redux action breadcrumbs (#24)
* Users can now configure the breadcrumb category
* Less code to maintain

Disadvantages
---

* Logger feature is removed