### PR TITLE
Make dummy middleware return the result of next()

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -18,7 +18,7 @@ export default function createMiddleware(dsn, cfg={}, options={}) {
       // Skip this middleware if there is no DSN.
       console.error('[redux-raven-middleware] Sentry DSN required.');
       return store => next => action => {
-        next(action);
+        return next(action);
       };
     }
     Raven.config(dsn, cfg).install();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-raven-middleware",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Redux middleware for sending error reports to Sentry through raven-js.",
   "main": "./index.js",
   "dependencies": {


### PR DESCRIPTION
We handle this properly in the real middleware, but not in the dummy middlware. Similar to <https://github.com/captbaritone/raven-for-redux/issues/11>